### PR TITLE
make errors deleting services fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,15 +46,15 @@ func main() {
 	for {
 		err := nodePortDeleter.DeleteServices()
 		if err != nil {
-			log.Errorf("Error return by service deleter: %s", err)
+			log.Fatalf("Error deleting services: %s", err)
 		}
 
 		select {
-			case signal := <-sigChan:
-				log.Printf("Caught %s, shutting down...", signal.String())
-				return
-			case <-timer.C:
-				timer.Reset(10 * time.Second)
+		case signal := <-sigChan:
+			log.Printf("Caught %s, shutting down...", signal.String())
+			return
+		case <-timer.C:
+			timer.Reset(10 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
This ensures that if the nodeportdeleter gets into a bad state, the pod will crash and start fresh, potentially self-healing or at least surfacing something being wrong.

We have observed such a behavior in the wild after restarting cilium.